### PR TITLE
Add support for html-webpack-plugin v3

### DIFF
--- a/strict-csp-html-webpack-plugin/plugin.js
+++ b/strict-csp-html-webpack-plugin/plugin.js
@@ -61,12 +61,14 @@ class StrictCspHtmlWebpackPlugin {
     compiler.hooks.compilation.tap(
       'StrictCspHtmlWebpackPlugin',
       (compilation) => {
-        this.htmlWebpackPlugin
-          .getHooks(compilation)
-          .beforeEmit.tapAsync(
-            'StrictCspHtmlWebpackPlugin',
-            this.processCsp.bind(this, compilation)
-          );
+        const hook = typeof this.htmlWebpackPlugin.getHooks === 'function' ?
+          this.htmlWebpackPlugin.getHooks(compilation).beforeEmit : // html-webpack-plugin v4 and above
+          compilation.hooks.htmlWebpackPluginAfterHtmlProcessing; // html-webpack-plugin v3
+
+        hook.tapAsync(
+          'StrictCspHtmlWebpackPlugin',
+          this.processCsp.bind(this, compilation)
+        );
       }
     );
   }


### PR DESCRIPTION
Vue CLI still uses html-webpack-plugin v3, so supporting it would be nice. :octocat: 

Reference: https://github.com/vuejs/vue-cli/blob/v4.5.14/packages/@vue/cli-service/package.json#L60