### PR TITLE
Add option for enabling `unsafe-eval`

### DIFF
--- a/strict-csp-html-webpack-plugin/README.md
+++ b/strict-csp-html-webpack-plugin/README.md
@@ -71,5 +71,6 @@ You can use additional options to configure the plugin:
 | -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `enabled`            | `true`  | When `true`, activates the plugin.                                                                                      |
 | `enableTrustedTypes` | `true`  | When `true`, enables [trusted types](https://web.dev/trusted-types) for additional protections against DOM XSS attacks. |
+| `enableUnsafeEval`   | `false` | When `true`, enables [unsafe-eval](https://web.dev/strict-csp/) in case you cannot remove all uses of `eval()`.         |
 
 

--- a/strict-csp-html-webpack-plugin/plugin.js
+++ b/strict-csp-html-webpack-plugin/plugin.js
@@ -19,6 +19,7 @@ const strictCspLib = require('strict-csp');
 const defaultOptions = {
   enabled: true,
   enableTrustedTypes: false,
+  enableUnsafeEval: false,
 };
 
 class StrictCspHtmlWebpackPlugin {
@@ -44,7 +45,8 @@ class StrictCspHtmlWebpackPlugin {
       const strictCsp = strictCspLib.StrictCsp.getStrictCsp(
         scriptHashes,
         this.options.enableTrustedTypes,
-        true
+        true,
+        this.options.enableUnsafeEval
       );
       strictCspModule.addMetaTag(strictCsp);
       htmlPluginData.html = strictCspModule.serializeDom();

--- a/strict-csp/index.ts
+++ b/strict-csp/index.ts
@@ -47,11 +47,15 @@ export class StrictCsp {
    * @param enableBrowserFallbacks If fallbacks for older browsers should be
    *   added. This is will not weaken the policy as modern browsers will ignore
    *   the fallbacks.
+   * @param enableUnsafeEval If you cannot remove all uses of eval(), you can
+   *   still set a strict CSP, but you will have to use the 'unsafe-eval'
+   *   keyword which will make your policy slightly less secure.
    */
   static getStrictCsp(
     hashes?: string[],
     enableTrustedTypes?: boolean,
-    enableBrowserFallbacks?: boolean
+    enableBrowserFallbacks?: boolean,
+    enableUnsafeEval?: boolean
   ): string {
     hashes = hashes || [];
     let strictCspTemplate = {
@@ -85,6 +89,12 @@ export class StrictCsp {
         ...strictCspTemplate,
         ...{ 'require-trusted-types-for': [`'script'`] },
       };
+    }
+
+    // If enabled, `eval()`-calls will be allowed, making the policy slightly
+    // less secure.
+    if (enableUnsafeEval) {
+      strictCspTemplate['script-src'].push(`'unsafe-eval'`);
     }
 
     return Object.entries(strictCspTemplate)


### PR DESCRIPTION
This option is often required when running webpack in development
mode, since it makes heavy use of `eval` in order to generate fast
source-maps.

See: https://webpack.js.org/configuration/devtool/