### PR TITLE
Allow `enableBrowserFallbacks` option to be overridden

### DIFF
--- a/strict-csp-html-webpack-plugin/README.md
+++ b/strict-csp-html-webpack-plugin/README.md
@@ -68,11 +68,12 @@ By default, strict-csp-html-webpack-plugin will set up a valid, strict, hash-bas
 
 You can use additional options to configure the plugin:
 
-| Option               | Default | What it does                                                                                                            |
-| -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `enabled`            | `true`  | When `true`, activates the plugin.                                                                                      |
-| `enableTrustedTypes` | `false`  | When `true`, enables [trusted types](https://web.dev/trusted-types) for additional protections against DOM XSS attacks. |
-| `enableUnsafeEval`   | `false` | When `true`, enables [unsafe-eval](https://web.dev/strict-csp/) in case you cannot remove all uses of `eval()`.         |
+| Option                   | Default | What it does                                                                                                            |
+| ------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                | `true`  | When `true`, activates the plugin.                                                                                      |
+| `enableBrowserFallbacks` | `true`  | When `true`, enables fallbacks for older browsers. This does not weaken the policy. |
+| `enableTrustedTypes`     | `false` | When `true`, enables [trusted types](https://web.dev/trusted-types) for additional protections against DOM XSS attacks. |
+| `enableUnsafeEval`       | `false` | When `true`, enables [unsafe-eval](https://web.dev/strict-csp/) in case you cannot remove all uses of `eval()`.         |
 
 ## FAQ
 

--- a/strict-csp-html-webpack-plugin/plugin.js
+++ b/strict-csp-html-webpack-plugin/plugin.js
@@ -18,6 +18,7 @@ const strictCspLib = require('strict-csp');
 
 const defaultOptions = {
   enabled: true,
+  enableBrowserFallbacks: true,
   enableTrustedTypes: false,
   enableUnsafeEval: false,
 };
@@ -42,9 +43,9 @@ class StrictCspHtmlWebpackPlugin {
       const strictCspModule = new strictCspLib.StrictCsp(htmlPluginData.html);
       strictCspModule.refactorSourcedScriptsForHashBasedCsp();
       const scriptHashes = strictCspModule.hashAllInlineScripts();
-      const { enableTrustedTypes, enableUnsafeEval } = this.options;
+      const { enableBrowserFallbacks, enableTrustedTypes, enableUnsafeEval } = this.options;
       const strictCsp = strictCspLib.StrictCsp.getStrictCsp(scriptHashes, {
-        enableBrowserFallbacks: true,
+        enableBrowserFallbacks,
         enableTrustedTypes,
         enableUnsafeEval,
       });


### PR DESCRIPTION
There wasn't an option to override the `enableBrowserFallbacks` option passed to `strict-csp`. With this PR you can override it for your specific use case.