### PR TITLE
feat: Added url hashes functionality

### DIFF
--- a/strict-csp/__snapshots__/index.test.ts.snap
+++ b/strict-csp/__snapshots__/index.test.ts.snap
@@ -259,6 +259,21 @@ exports[`StrictCsp with TrustedTypes should refactor scripts with Trusted Types 
       </html>"
 `;
 
+exports[`StrictCsp with script-src-v2 should generate url hashes correctly 1`] = `
+"
+      <!DOCTYPE html>
+      <html>
+        <head><meta http-equiv="Content-Security-Policy" content="script-src 'strict-dynamic' 'sha256-dIwX3/r4Zl0MpqRsxWkARQ0s7rnPg1QangRovs97KCI=' 'url-sha256-WEF+D3gbZlaUnTcljIuQUu0mbi63pRY8rXsIY+aykWo=' 'url-sha256-6XPsGGadES2PF3tgHkTa4UIcZZMBYDleKt2Jd1P/kIU=' https: 'unsafe-inline';object-src 'none';base-uri 'self';">
+          <title>Test</title>
+        </head>
+        <body>
+          <script src="main.js"></script>
+          <script src="abcd.js"></script>
+          <script>console.log('inline script');</script>
+        </body>
+      </html>"
+`;
+
 exports[`StrictCsp.process() CSP generation should generate a CSP with Trusted Types enabled 1`] = `"script-src 'strict-dynamic' 'sha256-tlts22Eu/seSWbAw80TfZJgYnelKmP4ds0Ijym8yNpY=' https: 'unsafe-inline';object-src 'none';base-uri 'self';require-trusted-types-for 'script';"`;
 
 exports[`StrictCsp.process() CSP generation should generate a CSP with all options enabled 1`] = `"script-src 'strict-dynamic' 'sha256-tlts22Eu/seSWbAw80TfZJgYnelKmP4ds0Ijym8yNpY=' https: 'unsafe-inline' 'unsafe-eval';object-src 'none';base-uri 'self';require-trusted-types-for 'script';"`;

--- a/strict-csp/index.test.ts
+++ b/strict-csp/index.test.ts
@@ -225,3 +225,30 @@ describe('StrictCsp with TrustedTypes', () => {
     expect(html).toMatchSnapshot();
   });
 });
+
+
+describe('StrictCsp with script-src-v2', () => {
+  it('should generate url hashes correctly', () => {
+    const initialHtml = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Test</title>
+        </head>
+        <body>
+          <script src="main.js"></script>
+          <script src="abcd.js"></script>
+          <script>console.log('inline script');</script>
+        </body>
+      </html>`;
+
+    const processor = new StrictCsp(initialHtml, {
+      browserFallbacks: true,
+      strictSrcV2: true,
+    });
+    const { csp } = processor.process();
+    const finalHtml = processor.serializeDomWithStrictCspMetaTag(csp);
+
+    expect(finalHtml).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Added a mechanism to allow developers to allowlist external scripts by the hash of their URL, rather than their content. For example:  script-src 'url-sha256-S4wce32J...'; (where the hash is of "https://example.com/script.js").
This feature directly addresses the main drawback of the original strict-csp approach. Instead of removing all <script src> tags and replacing them with a complex loader, developers can now keep the original script tags in their HTML and simply allowlist them by their URL's hash. This avoids significant HTML rewriting and eliminates complex script load ordering bugs that we had observed.


